### PR TITLE
fix with silkspawners

### DIFF
--- a/src/main/resources/assets/craftablemobs/recipes/spawner.json
+++ b/src/main/resources/assets/craftablemobs/recipes/spawner.json
@@ -14,6 +14,7 @@
     }
   },
   "result": {
-    "item": "minecraft:mob_spawner"
+    "item": "minecraft:mob_spawner",
+    "data": 0
   }
 }


### PR DESCRIPTION
this fixes it with silkspawners even though I might not need getHasSubtypes() to be true with nbt and using metadata of 0 it's better to be safe