### PR TITLE
make this addon compatible

### DIFF
--- a/src/main/java/io/github/msathieu/craftablemobs/CraftableMobs.java
+++ b/src/main/java/io/github/msathieu/craftablemobs/CraftableMobs.java
@@ -80,7 +80,7 @@ public class CraftableMobs {
   
   public static void registerModEgg(ResourceLocation mob,Item ingredient){
     ItemStack egg = new ItemStack(Items.SPAWN_EGG);
-    ItemMonsterPlacer.applyEntityIdToItemStack(egg, new ResourceLocation("minecraft:" + mob));
+    ItemMonsterPlacer.applyEntityIdToItemStack(egg, mob);
     GameRegistry.addShapedRecipe(new ResourceLocation("craftablemobs:" + mob + "_egg"), eggsGroup, egg, new Object[] {
       "III",
       "IEI",

--- a/src/main/java/io/github/msathieu/craftablemobs/CraftableMobs.java
+++ b/src/main/java/io/github/msathieu/craftablemobs/CraftableMobs.java
@@ -68,6 +68,10 @@ public class CraftableMobs {
     registerEgg(mob, Item.getItemFromBlock(ingredient));
   }
   
+  public static void registerEgg(ResourceLocation mob, Block ingredient) {
+    registerModEgg(mob, Item.getItemFromBlock(ingredient));
+  }
+  
   public static final ResourceLocation eggsGroup = new ResourceLocation("craftablemobs:eggs");
   
   public static void registerEgg(String mob, Item ingredient) {

--- a/src/main/java/io/github/msathieu/craftablemobs/CraftableMobs.java
+++ b/src/main/java/io/github/msathieu/craftablemobs/CraftableMobs.java
@@ -64,11 +64,17 @@ public class CraftableMobs {
     registerEgg("vex", Items.IRON_SWORD);
     registerEgg("skeleton_horse", Blocks.BONE_BLOCK);
   }
-  private void registerEgg(String mob, Block ingredient) {
+  public static void registerEgg(String mob, Block ingredient) {
     registerEgg(mob, Item.getItemFromBlock(ingredient));
   }
-  private void registerEgg(String mob, Item ingredient) {
-    ResourceLocation eggsGroup = new ResourceLocation("craftablemobs:eggs");
+  
+  public static final ResourceLocation eggsGroup = new ResourceLocation("craftablemobs:eggs");
+  
+  public static void registerEgg(String mob, Item ingredient) {
+      registerModEgg(new ResourceLocation("minecraft",mob),ingredient);
+  }
+  
+  public static void registerModEgg(ResourceLocation mob,Item ingredient){
     ItemStack egg = new ItemStack(Items.SPAWN_EGG);
     ItemMonsterPlacer.applyEntityIdToItemStack(egg, new ResourceLocation("minecraft:" + mob));
     GameRegistry.addShapedRecipe(new ResourceLocation("craftablemobs:" + mob + "_egg"), eggsGroup, egg, new Object[] {
@@ -79,4 +85,5 @@ public class CraftableMobs {
       'E', Items.SPAWN_EGG
     });
   }
+
 }


### PR DESCRIPTION
make this addon compatible. private non objects. there is no reason for your methods to be object nor private. this also allows mods to simply add their own recipes for compatibility. Although you could try to automate recipes even more but, some mobs could drop multiple items so it could be mob specific.